### PR TITLE
Respect LDFLAGS and explicitly link to math library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CFLAGS=-O3 -Wall -Wextra
 
 
 pigz: pigz.o yarn.o zopfli/deflate.o zopfli/blocksplitter.o zopfli/tree.o zopfli/lz77.o zopfli/cache.o zopfli/hash.o zopfli/util.o zopfli/squeeze.o zopfli/katajainen.o
-	$(CC) -o pigz $^ -lpthread -lz
+	$(CC) $(LDFLAGS) -o pigz $^ -lpthread -lz -lm
 	ln -f pigz unpigz
 
 pigz.o: pigz.c yarn.h zopfli/deflate.h zopfli/util.h


### PR DESCRIPTION
This makes the build process respect the environment's LDFLAGS and explicitly links to the math library fixing linking errors that can arise such as the following:

tree.c:(.text+0x1a5): undefined reference to `log'
