### PR TITLE
fix for MinGW

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC=cc
-CFLAGS=-O3 -Wall -Wextra
+CFLAGS=-O3 -Wall -Wextra -std=c99
 
 
 pigz: pigz.o yarn.o zopfli/deflate.o zopfli/blocksplitter.o zopfli/tree.o zopfli/lz77.o zopfli/cache.o zopfli/hash.o zopfli/util.o zopfli/squeeze.o zopfli/katajainen.o

--- a/pigz.c
+++ b/pigz.c
@@ -324,6 +324,17 @@
 #  include <sys/pstat.h>
 #endif
 
+#ifdef __MINGW32__
+#  define S_IFLNK      0
+#  define chown(a,b,c) 0
+#  define utimes(a,b)  0
+#  define lstat(a,b)   stat(a,b)
+#  define _exit(n)     exit(n)
+#  pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#  pragma GCC diagnostic ignored "-Wunused-parameter"
+#  pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+
 #include "zlib.h"       /* deflateInit2(), deflateReset(), deflate(), */
                         /* deflateEnd(), deflateSetDictionary(), crc32(),
                            inflateBackInit(), inflateBack(), inflateBackEnd(),


### PR DESCRIPTION
This patch makes it possible to compile pigz on MinGW for Windows.

* Tested with the latest published compiler from the mingw project (4.7.2)
* Disabled a few warnings when compiled on mingw, which sprung up when I nulled the functions that are missing on Windows.
* Also made it explicit that the c99 mode should be used during compilation, as I take it that was your implicit intent. Without setting it explicitly, mingw's GCC fails to find the enhanced printf-function that is able to handle the extended formats you use.