### PR TITLE
Increase maximum allowed blocksize.

### DIFF
--- a/pigz.c
+++ b/pigz.c
@@ -3873,7 +3873,7 @@ local int option(char *arg)
             if (n != g.block >> 10 ||
                 OUTPOOL(g.block) < g.block ||
                 (ssize_t)OUTPOOL(g.block) < 0 ||
-                g.block > (1UL << 22))
+                g.block > (1UL << 30))
                 bail("block size too large: ", arg);
             new_opts();
         }


### PR DESCRIPTION
Earlier versions of pigz did not limit the blocksize
to 4MiB. I have found that when compressing large files
on fast storage there is a substantial speed-up when
using blocksizes > 4 MiB.