### PR TITLE
Add Blocked GZip Format (BGZF)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,68 @@ pigzn: pigzn.o zopfli/deflate.o zopfli/blocksplitter.o zopfli/tree.o zopfli/lz77
 pigzn.o: pigz.c
 	$(CC) $(CFLAGS) -DDEBUG -DNOTHREAD -g -c -o pigzn.o pigz.c
 
-test: pigz
+#
+# set up pattern rules for tests
+#
+
+LONG_NAME = VeryLongNameVeryLongNameVeryLongNameVeryLongNameVeryLongNameVeryLongNameVeryLongNameVeryLongNameVeryLongNameVeryLongNameVeryLongNameVeryLongNameVeryLongNameVeryLongNameVeryLongNameVeryLongNameVeryLongNameVeryLongName
+
+TESTFILES =  $(addprefix .testfile-, empty pigz.c largefile $(LONG_NAME) )
+
+.testfile-empty:
+	cat /dev/null > $@
+
+.testfile-pigz.c: pigz.c
+	cp pigz.c $@
+
+.testfile-largefile: pigz.c
+	number=1 ; while [[ $$number -le 100 ]] ; do cat pigz.c >> $@ ; ((number = number + 1)) ; done
+
+.testfile-$(LONG_NAME): .testfile-largefile
+	cp $< $@
+
+TEST_OPTIONS = .gz .b32.gz .1.gz .B.gz .B1.gz .gz2.gz .B-gz2.gz
+
+.testfile-%.gz : .testfile-% pigz
+	./pigz -kf $< && touch $@
+
+.testfile-%.b32.gz : .testfile-% pigz
+	./pigz -kfb 32 $< && mv $<.gz $@ && touch $@
+
+.testfile-%.1.gz : .testfile-% pigz
+	./pigz -kfp 1 $< && mv $<.gz $@ && touch $@
+
+.testfile-%.B.gz : .testfile-% pigz
+	./pigz -kfB $< && mv $<.gz $@ && touch $@
+
+.testfile-%.B1.gz : .testfile-% pigz
+	./pigz -kfBp 1 $< && mv $<.gz $@ && touch $@
+
+.testfile-%.gz2.gz : .testfile-% pigz
+	./pigz -kf $< && ./pigz -kf $<.gz && mv $<.gz.gz $@ && touch $@
+
+.testfile-%.B-gz2.gz : .testfile-% pigz
+	./pigz -kfB $< && ./pigz -kfB $<.gz && mv $<.gz.gz $@ && touch $@
+
+.test% : %.gz pigz
+	./pigz -t $<
+	./pigz -tp 1 $<
+	gzip -t $<
+	./pigz -dc $< > $@.out && diff -q $@.out $*
+	./pigz -dcp 1 $< > $@.out && diff -q $@.out $*
+	gzip -dc $< > $@.out && diff -q $@.out $*
+
+TESTFILES_GZ = $(foreach option, $(TEST_OPTIONS), $(addsuffix $(option), $(TESTFILES)) )
+
+testfiles : $(TESTFILES) $(TESTFILES_GZ)
+
+TESTS = $(addprefix .test, $(TESTFILES_GZ))
+
+.SECONDARY : $(TESTFILES) $(TESTFILES_GZ) $(TESTS)
+
+moretests : pigz $(TESTS)
+
+test: pigz moretests
 	./pigz -kf pigz.c ; ./pigz -t pigz.c.gz
 	./pigz -kfb 32 pigz.c ; ./pigz -t pigz.c.gz
 	./pigz -kfp 1 pigz.c ; ./pigz -t pigz.c.gz
@@ -62,10 +123,15 @@ test: pigz
 	  echo 'compress -f < pigz.c | ./unpigz | cmp - pigz.c' ;\
 	  compress -f < pigz.c | ./unpigz | cmp - pigz.c ;\
 	fi
+	./pigz -cp 1 < /dev/null | ./pigz -t -
+	./pigz -c < /dev/null | ./pigz -t -
+	./pigz -kfB -p 1 pigz.c \
+	&& ./pigz -d -c -p 1 pigz.c.gz | diff -q - pigz.c \
+	&& ./pigz -d -c -p 2 pigz.c.gz | diff -q - pigz.c
 	./pigz -kfB pigz.c \
 	&& ./pigz -d -c -p 1 pigz.c.gz | diff -q - pigz.c \
 	&& ./pigz -d -c -p 2 pigz.c.gz | diff -q - pigz.c
-	@rm -f pigz.c.gz pigz.c.zz pigz.c.zip
+	@rm -f pigz.c.gz pigz.c.zz pigz.c.zip .test*
 
 tests: dev test
 	./pigzn -kf pigz.c ; ./pigz -t pigz.c.gz
@@ -77,4 +143,4 @@ pigz.pdf: pigz.1
 	groff -mandoc -f H -T ps pigz.1 | ps2pdf - pigz.pdf
 
 clean:
-	@rm -f *.o zopfli/*.o pigz unpigz pigzn pigzt pigz.c.gz pigz.c.zz pigz.c.zip
+	@rm -f *.o zopfli/*.o pigz unpigz pigzn pigzt pigz.c.gz pigz.c.zz pigz.c.zip .test*


### PR DESCRIPTION
This patch adds the ability for pigz to compress and uncompress the Blocked GNU Zip Format (BGZF) variant of gzip whose specification can be found here in the SAM specification.  http://samtools.github.io/hts-specs/SAMv1.pdf

This format uses an extra field in the gzip header to encode each independent block's length, thereby allowing parallel decompression and even fast random access of the compressed archive (with indexing or other tricks)

I hope that people interested in parallel compression will be willing to sacrifice a small amount of compression-space efficiency for the ability to greatly accelerate the speed and parallelism of decompression.
