### PR TITLE
Fix allowing compilation on mingw and cygwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,15 @@
 CC=cc
 CFLAGS=-O3 -Wall -Wextra
+ifeq ($(OS),Windows_NT)
+  CFLAGS += -std=c99
+  LIBS = -lz
+endif
 LDFLAGS=-lz
 ZOPFLI=zopfli/src/zopfli/
 # use gcc and gmake on Solaris
 
 pigz: pigz.o yarn.o try.o ${ZOPFLI}deflate.o ${ZOPFLI}blocksplitter.o ${ZOPFLI}tree.o ${ZOPFLI}lz77.o ${ZOPFLI}cache.o ${ZOPFLI}hash.o ${ZOPFLI}util.o ${ZOPFLI}squeeze.o ${ZOPFLI}katajainen.o
-	$(CC) $(LDFLAGS) -o pigz $^ -lpthread -lm
+	$(CC) $(LDFLAGS) -o pigz $^ $(LIBS) -lpthread -lm
 	ln -f pigz unpigz
 
 pigz.o: pigz.c yarn.h try.h ${ZOPFLI}deflate.h ${ZOPFLI}util.h
@@ -35,7 +39,7 @@ ${ZOPFLI}katajainen.o: ${ZOPFLI}katajainen.c ${ZOPFLI}katajainen.h
 dev: pigz pigzt pigzn
 
 pigzt: pigzt.o yarnt.o try.o ${ZOPFLI}deflate.o ${ZOPFLI}blocksplitter.o ${ZOPFLI}tree.o ${ZOPFLI}lz77.o ${ZOPFLI}cache.o ${ZOPFLI}hash.o ${ZOPFLI}util.o ${ZOPFLI}squeeze.o ${ZOPFLI}katajainen.o
-	$(CC) $(LDFLAGS) -o pigzt $^ -lpthread -lm
+	$(CC) $(LDFLAGS) -o pigzt $^ $(LIBS) -lpthread -lm
 
 pigzt.o: pigz.c yarn.h try.h
 	$(CC) $(CFLAGS) -DDEBUG -g -c -o pigzt.o pigz.c
@@ -44,7 +48,7 @@ yarnt.o: yarn.c yarn.h
 	$(CC) $(CFLAGS) -DDEBUG -g -c -o yarnt.o yarn.c
 
 pigzn: pigzn.o tryn.o ${ZOPFLI}deflate.o ${ZOPFLI}blocksplitter.o ${ZOPFLI}tree.o ${ZOPFLI}lz77.o ${ZOPFLI}cache.o ${ZOPFLI}hash.o ${ZOPFLI}util.o ${ZOPFLI}squeeze.o ${ZOPFLI}katajainen.o
-	$(CC) $(LDFLAGS) -o pigzn $^ -lm
+	$(CC) $(LDFLAGS) -o pigzn $^ $(LIBS) -lm
 
 pigzn.o: pigz.c try.h
 	$(CC) $(CFLAGS) -DDEBUG -DNOTHREAD -g -c -o pigzn.o pigz.c

--- a/pigz.c
+++ b/pigz.c
@@ -362,6 +362,18 @@
 #  include <sys/pstat.h>
 #endif
 
+#ifdef __MINGW32__
+#  define S_IFLNK      0
+#  define chown(a,b,c) 0
+#  define utimes(a,b)  0
+#  define lstat(a,b)   stat(a,b)
+#  define _exit(n)     exit(n)
+#  define ECANCELED    SIGINT
+#  define EOVERFLOW    ERANGE
+#  pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#  pragma GCC diagnostic ignored "-Wunused-parameter"
+#endif
+
 #include "zlib.h"       /* deflateInit2(), deflateReset(), deflate(), */
                         /* deflateEnd(), deflateSetDictionary(), crc32(),
                            adler32(), inflateBackInit(), inflateBack(),


### PR DESCRIPTION
Hi Mark, this is a new attempt to get you changes needed for successful compilation on Windows. The previous pull request ( #9 ) had issues as you noted, and I've addressed that feedback by only modifying the compiler flags if make is run on windows (mingw or cygwin).

I didn't dare move the position of LDFLAGS in the `Makefile` since I'm unable to test all the other platforms you are able to reach. Instead I added a new variable that only contains value when run on Windows. Thus the behavior should be unchanged on any other platform, and not break things this time around.

_Of course, it would be a bit cleaner (look tidier) to add the zlib linking reference just once, and if you find moving the linker directive after the list of objects to link doesn't break compilation on other platforms, then let me know and I'll just move the position of LDFLAGS instead._

Since 2013, I discovered you have introduced use of the error signals `ECANCELED` and `EOVERFLOW`. These two don't exist in MinGW, so I've tried to find two signals that are semantically similar. Again, let me know if you're not happy with the semantic aliasing and have others you'd think would better suited.