### PR TITLE
Use LIBS for libraries (-lz), instead of LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 CC=cc
 CFLAGS=-O3 -Wall -Wextra
-LDFLAGS=-lz
+LDFLAGS=
+LIBS=-lz
 ZOPFLI=zopfli/src/zopfli/
 # use gcc and gmake on Solaris
 
 pigz: pigz.o yarn.o try.o ${ZOPFLI}deflate.o ${ZOPFLI}blocksplitter.o ${ZOPFLI}tree.o ${ZOPFLI}lz77.o ${ZOPFLI}cache.o ${ZOPFLI}hash.o ${ZOPFLI}util.o ${ZOPFLI}squeeze.o ${ZOPFLI}katajainen.o
-	$(CC) $(LDFLAGS) -o pigz $^ -lpthread -lm
+	$(CC) $(LDFLAGS) -o pigz $^ -lpthread -lm $(LIBS)
 	ln -f pigz unpigz
 
 pigz.o: pigz.c yarn.h try.h ${ZOPFLI}deflate.h ${ZOPFLI}util.h
@@ -35,7 +36,7 @@ ${ZOPFLI}katajainen.o: ${ZOPFLI}katajainen.c ${ZOPFLI}katajainen.h
 dev: pigz pigzt pigzn
 
 pigzt: pigzt.o yarnt.o try.o ${ZOPFLI}deflate.o ${ZOPFLI}blocksplitter.o ${ZOPFLI}tree.o ${ZOPFLI}lz77.o ${ZOPFLI}cache.o ${ZOPFLI}hash.o ${ZOPFLI}util.o ${ZOPFLI}squeeze.o ${ZOPFLI}katajainen.o
-	$(CC) $(LDFLAGS) -o pigzt $^ -lpthread -lm
+	$(CC) $(LDFLAGS) -o pigzt $^ -lpthread -lm $(LIBS)
 
 pigzt.o: pigz.c yarn.h try.h
 	$(CC) $(CFLAGS) -DDEBUG -g -c -o pigzt.o pigz.c
@@ -44,7 +45,7 @@ yarnt.o: yarn.c yarn.h
 	$(CC) $(CFLAGS) -DDEBUG -g -c -o yarnt.o yarn.c
 
 pigzn: pigzn.o tryn.o ${ZOPFLI}deflate.o ${ZOPFLI}blocksplitter.o ${ZOPFLI}tree.o ${ZOPFLI}lz77.o ${ZOPFLI}cache.o ${ZOPFLI}hash.o ${ZOPFLI}util.o ${ZOPFLI}squeeze.o ${ZOPFLI}katajainen.o
-	$(CC) $(LDFLAGS) -o pigzn $^ -lm
+	$(CC) $(LDFLAGS) -o pigzn $^ -lm $(LIBS)
 
 pigzn.o: pigz.c try.h
 	$(CC) $(CFLAGS) -DDEBUG -DNOTHREAD -g -c -o pigzn.o pigz.c


### PR DESCRIPTION
I'm getting linker errors, when trying to link the objects before zlib.
Moving -lz to the back (next to -lm) of the line makes it work again.