### PR TITLE
Makefile: Fix undefined reference to `adler32'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 CC=cc
 CFLAGS=-O3 -Wall -Wextra
-LDFLAGS=-lz
+LDLIBS=-lz
 ZOPFLI=zopfli/src/zopfli/
 # use gcc and gmake on Solaris
 
 pigz: pigz.o yarn.o try.o ${ZOPFLI}deflate.o ${ZOPFLI}blocksplitter.o ${ZOPFLI}tree.o ${ZOPFLI}lz77.o ${ZOPFLI}cache.o ${ZOPFLI}hash.o ${ZOPFLI}util.o ${ZOPFLI}squeeze.o ${ZOPFLI}katajainen.o
-	$(CC) $(LDFLAGS) -o pigz $^ -lpthread -lm
+	$(CC) $(LDFLAGS) -o pigz $^ -lpthread -lm $(LDLIBS)
 	ln -f pigz unpigz
 
 pigz.o: pigz.c yarn.h try.h ${ZOPFLI}deflate.h ${ZOPFLI}util.h
@@ -35,7 +35,7 @@ ${ZOPFLI}katajainen.o: ${ZOPFLI}katajainen.c ${ZOPFLI}katajainen.h
 dev: pigz pigzt pigzn
 
 pigzt: pigzt.o yarnt.o try.o ${ZOPFLI}deflate.o ${ZOPFLI}blocksplitter.o ${ZOPFLI}tree.o ${ZOPFLI}lz77.o ${ZOPFLI}cache.o ${ZOPFLI}hash.o ${ZOPFLI}util.o ${ZOPFLI}squeeze.o ${ZOPFLI}katajainen.o
-	$(CC) $(LDFLAGS) -o pigzt $^ -lpthread -lm
+	$(CC) $(LDFLAGS) -o pigzt $^ -lpthread -lm $(LDLIBS)
 
 pigzt.o: pigz.c yarn.h try.h
 	$(CC) $(CFLAGS) -DDEBUG -g -c -o pigzt.o pigz.c
@@ -44,7 +44,7 @@ yarnt.o: yarn.c yarn.h
 	$(CC) $(CFLAGS) -DDEBUG -g -c -o yarnt.o yarn.c
 
 pigzn: pigzn.o tryn.o ${ZOPFLI}deflate.o ${ZOPFLI}blocksplitter.o ${ZOPFLI}tree.o ${ZOPFLI}lz77.o ${ZOPFLI}cache.o ${ZOPFLI}hash.o ${ZOPFLI}util.o ${ZOPFLI}squeeze.o ${ZOPFLI}katajainen.o
-	$(CC) $(LDFLAGS) -o pigzn $^ -lm
+	$(CC) $(LDFLAGS) -o pigzn $^ -lm $(LDLIBS)
 
 pigzn.o: pigz.c try.h
 	$(CC) $(CFLAGS) -DDEBUG -DNOTHREAD -g -c -o pigzn.o pigz.c


### PR DESCRIPTION
`-lz` must come at the end of the link line. Fixes the error message seen on Ubuntu 14:

```
/usr/bin/gcc-4.8 -lz -o pigz pigz.o yarn.o try.o zopfli/src/zopfli/deflate.o zopfli/src/zopfli/blocksplitter.o zopfli/src/zopfli/tree.o zopfli/src/zopfli/lz77.o zopfli/src/zopfli/cache.o zopfli/src/zopfli/hash.o zopfli/src/zopfli/util.o zopfli/src/zopfli/squeeze.o zopfli/src/zopfli/katajainen.o -lpthread -lm
pigz.o: In function `outb':
pigz.c:(.text+0x4c7): undefined reference to `adler32'
pigz.c:(.text+0x4ce): undefined reference to `crc32'
```

See https://github.com/Linuxbrew/homebrew-core/pull/414
