### PR TITLE
Expose -H huffman option when NOZOPFLI is defined.

### DIFF
--- a/pigz.c
+++ b/pigz.c
@@ -4433,7 +4433,9 @@ local int option(char *arg) {
 #ifndef NOZOPFLI
             case 'F':  g.zopts.blocksplittinglast = 1;  break;
             case 'I':  get = 4;  break;
+#endif
             case 'H':  g.strategy = Z_HUFFMAN_ONLY;  break;
+#ifndef NOZOPFLI
             case 'J':  get = 5;  break;
 #endif
             case 'K':  g.form = 2;  g.sufx = ".zip";  break;


### PR DESCRIPTION
The `--huffman` option is supposed to be enabled even when `NOZOPFLI` is defined.

![image](https://user-images.githubusercontent.com/1364432/120731591-cd196a00-c498-11eb-8020-a762778d3d7e.png)
