### PR TITLE
Do not set mtime when not reading from file

### DIFF
--- a/pigz.c
+++ b/pigz.c
@@ -3922,8 +3922,7 @@ local void process(char *path) {
         vstrcpy(&g.inf, &g.inz, 0, "<stdin>");
         g.ind = 0;
         g.name = NULL;
-        g.mtime = g.headis & 2 ?
-                  (fstat(g.ind, &st) ? time(NULL) : st.st_mtime) : 0;
+        g.mtime = 0;
         len = 0;
     }
     else {


### PR DESCRIPTION
Currently `tar --gzip/-z/-Igzip` produces deterministic tarballs from
the same input, because it sets a 0 modification time in the gzip
header.

On the other hand, `tar -Ipigz` does not produce deterministic output,
because it uses the current time as modification time.

It would be good to be consistent with gzip here.
