### PR TITLE
Do not use `strcpy()` for overlapping blocks

### DIFF
--- a/pigz.c
+++ b/pigz.c
@@ -3124,8 +3124,12 @@ local void show_info(int method, unsigned long check, length_t len, int cont) {
     if (g.stamp && !cont) {
         strcpy(mod, ctime(&g.stamp));
         now = time(NULL);
-        if (strcmp(mod + 20, ctime(&now) + 20) != 0)
-            strcpy(mod + 11, mod + 19);
+        if (strcmp(mod + 20, ctime(&now) + 20) != 0) {
+            // use memmove() for overlapping blocks rather than strcpy()
+            char *dst = mod + 11;
+            char const *src = mod + 19;
+            memmove(dst, src, strlen(src) + 1);
+        }
     }
     else
         strcpy(mod + 4, "------ -----");


### PR DESCRIPTION
... to avoid undefined behavior.  Use `memmove()` instead. Detected by Coverity:
```
Error: BUFFER_SIZE (CWE-474):
pigz.c:3128: overlapping_buffer: The source buffer "mod + 19" potentially overlaps with the destination buffer "mod + 11", which results in undefined behavior for "strcpy".
pigz.c:3128: remediation: Replace "strcpy(dest, src)" with "memmove(dest, src, strlen(src)+1)".
3126|           now = time(NULL);
3127|           if (strcmp(mod + 20, ctime(&now) + 20) != 0)
3128|->             strcpy(mod + 11, mod + 19);
3129|       }
3130|       else
```