### PR TITLE
Compatibility has been adjusted for Solaris builds.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC=gcc
-CFLAGS=-O3 -Wall -Wextra -Wno-unknown-pragmas -Wcast-qual
+CFLAGS=-O3 -Wall -Wextra -Wno-unknown-pragmas -Wcast-qual -D__EXTENSIONS__
 LDFLAGS=
 # CFLAGS=-O3 -Wall -Wextra -Wno-unknown-pragmas -Wcast-qual -g -fsanitize=thread
 # LDFLAGS=-g -fsanitize=thread

--- a/pigz.c
+++ b/pigz.c
@@ -346,7 +346,9 @@
 // Portability defines.
 #define _FILE_OFFSET_BITS 64            // Use large file functions
 #define _LARGE_FILES                    // Same thing for AIX
-#define _XOPEN_SOURCE 700               // For POSIX 2008
+#ifndef _XOPEN_SOURCE
+#define _XOPEN_SOURCE 600               // Require to build with gcc on Solaris
+#endif
 
 // Included headers and what is expected from each.
 #include <stdio.h>      // fflush(), fprintf(), fputs(), getchar(), putc(),

--- a/yarn.c
+++ b/yarn.c
@@ -26,7 +26,9 @@
  */
 
 // For thread portability.
-#define _XOPEN_SOURCE 700
+#ifndef _XOPEN_SOURCE
+#define _XOPEN_SOURCE 600
+#endif
 #define _POSIX_C_SOURCE 200809L
 #define _THREAD_SAFE
 


### PR DESCRIPTION
On Solaris with older versions of gcc, the build fails the compatibility test with the error "Compiler or options invalid for pre-UNIX 03 X/Open applications and pre-2001 POSIX applications." To address this, the compatibility level has been slightly lowered without losing the ability to compile.

**Note**: _XOPEN_SOURCE=600 is enough for successful compilation on Solaris 10 with gcc 5.x, it also compiles successfully on Debian 13 with gcc 14.2.